### PR TITLE
Fix a copy/paste error

### DIFF
--- a/cache/common/README.md
+++ b/cache/common/README.md
@@ -1,4 +1,4 @@
-# volos-quota-common
+# volos-cache-common
 
 This module adds support for caching to any API.
 

--- a/cache/memory/README.md
+++ b/cache/memory/README.md
@@ -1,8 +1,8 @@
-# volos-quota-memory
+# volos-cache-memory
 
-This is a memory-backed implementation of quota support for Volos.
+This is a memory-backed implementation of cache support for Volos.
 
-Once initialized, the interface to the module is exactly what is in the "volos-quota-common" module. See
+Once initialized, the interface to the module is exactly what is in the "volos-cache-common" module. See
 that module for detailed docs.
 
 ## Initialization
@@ -14,4 +14,4 @@ The options can contain the following parameters:
  encoding: the default string encoding to use for cached values (optional)
 
 Note: The cache name represents a namespace. A created cache will share values (but not necessary options)
-with other volos-quota-memory caches on this node you create using the same name.
+with other volos-cache-memory caches on this node you create using the same name.

--- a/cache/redis/README.md
+++ b/cache/redis/README.md
@@ -1,8 +1,8 @@
-# volos-quota-redis
+# volos-cache-redis
 
-This is a redis-backed implementation of quota support for Volos.
+This is a redis-backed implementation of cache support for Volos.
 
-Once initialized, the interface to the module is exactly what is in the "volos-quota-common" module. See
+Once initialized, the interface to the module is exactly what is in the "volos-cache-common" module. See
 that module for detailed docs.
 
 ## Initialization
@@ -17,4 +17,4 @@ The options can contain the following parameters:
  options:  redis options (hash, optional) - note: return_buffers will be forced to true
 
 Note: The cache name represents a namespace. A created cache will share values (but not necessary options)
-with other volos-quota-redis caches on this node you create using the same name.
+with other volos-cache-redis caches on this node you create using the same name.


### PR DESCRIPTION
It looks like the quota README was copied to cache, but some quota
references were not changed to cache.
