### PR TITLE
Set private to true in root level package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "Volos",
   "version": "0.9.0",
   "comments": "This package.json is here so we can get dependencies to run tests",
+  "private": true,
   "dependencies":  {
     "express": "3.4.x",
     "argo": "0.4.x",


### PR DESCRIPTION
This will make sure npm does not publish this package.json and makes it clear to developers that this is not the package that you install via npm.
