### PR TITLE
Add missing underscore dependency for redis cache and quota module

### DIFF
--- a/cache/redis/package.json
+++ b/cache/redis/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "volos-cache-common": "0.9.x",
     "debug": "1.0.x",
+    "underscore" : "1.6.x",
     "redis": "0.10.x"
   },
   "devDependencies": {},

--- a/quota/redis/package.json
+++ b/quota/redis/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "volos-quota-common": "0.9.x",
     "debug": "1.0.x",
+    "underscore" : "1.6.x",
     "redis": "0.10.x"
   },
   "devDependencies": {},


### PR DESCRIPTION
The redis cache and redis quota modules are using underscore but don't have it in their package.json.

This should fix #16 for now.
