### PR TITLE
Better error on remote proxy mis-configuration

### DIFF
--- a/oauth/apigee/lib/apigeeruntime.js
+++ b/oauth/apigee/lib/apigeeruntime.js
@@ -117,7 +117,7 @@ function selectImplementation(self, cb) {
           debug('Error getting version: %s', err);
           cb(err);
         } else {
-          if (resp.notFound || !semver.satisfies(resp.text, '>=1.1.0')) {
+          if (resp.notFound || (resp.ok && !semver.satisfies(resp.text, '>=1.1.0'))) {
             debug('Selected remote implementation with old protocol');
             self.impl = new oldImpl.OldRemoteOAuth(self);
             cb(undefined, self.impl);
@@ -125,8 +125,10 @@ function selectImplementation(self, cb) {
             debug('Selected remote implementation with new protocol');
             self.impl = new newImpl.OAuthImpl(self, false);
             cb(undefined, self.impl);
+          } else if (resp.unauthorized) {
+            cb(new Error('Not authorized to call the remote proxy. Check the "key" parameter.'));
           } else {
-            cb(new Error(util.format('HTTP error getting proxy version: %d', resp.statusCode)));
+            cb(new Error(util.format('HTTP error getting proxy version: %d. Check the "uri" parameter.', resp.statusCode)));
           }
         }
     });

--- a/quota/apigee/lib/apigeequota.js
+++ b/quota/apigee/lib/apigeequota.js
@@ -140,7 +140,7 @@ function selectImplementation(self, cb) {
         if (err) {
           cb(err);
         } else {
-          if (resp.notFound || !semver.satisfies(resp.text, '>=1.1.0')) {
+          if (resp.notFound || (resp.ok && !semver.satisfies(resp.text, '>=1.1.0'))) {
             if (self.options.startTime) {
               cb(new Error('Quotas with a fixed starting time are not supported'));
             } else {
@@ -150,8 +150,10 @@ function selectImplementation(self, cb) {
           } else if (resp.ok) {
             self.quotaImpl = new ApigeeRemoteQuota(self);
             cb(undefined, self.quotaImpl);
+          } else if (resp.unauthorized) {
+            cb(new Error('Not authorized to call the remote proxy. Check the "key" parameter.'));
           } else {
-            cb(new Error(util.format('HTTP error getting proxy version: %d', resp.statusCode)));
+            cb(new Error(util.format('HTTP error getting proxy version: %d. Check the "uri" parameter.', resp.statusCode)));
           }
         }
     });


### PR DESCRIPTION
Improve error message that is generated when the "remote proxy" cannot be contacted.

This one function is common between multiple apigee providers and should eventually make its way into a new module called "volos-apigee-common". However at the moment it's just one function and that seems like a bit much.
