### PR TITLE
Pass attributes to refreshed token

### DIFF
--- a/oauth/redis/lib/redisruntime.js
+++ b/oauth/redis/lib/redisruntime.js
@@ -241,6 +241,7 @@ RedisRuntimeSpi.prototype.refreshToken = function(options, cb) {
     if (reply) {
       var token = JSON.parse(reply);
       options.scope = token.scope;
+      options.attributes = token.attributes;
       createAndStoreToken(self, options, function(err, reply) {
         if (err) { return cb(err); }
         self.client.del(key);

--- a/oauth/test/extensions_test.js
+++ b/oauth/test/extensions_test.js
@@ -150,6 +150,35 @@ exports.verifyOauth = function(config) {
           });
         });
       });
+
+      it('refresh token', function(done) {
+        var body = {
+          grant_type: 'password',
+          username: validUserCreds.username,
+          password: validUserCreds.password,
+          client_id: client_id,
+          client_secret: client_secret
+        };
+        oauth.generateToken(body, options, function(err, token) {
+          should.not.exist(err);
+          should.exist(token.attributes.foo);
+          should.exist(token.refresh_token);
+          token.attributes.foo.should.equal(options.attributes.foo);
+
+          var body = {
+            grant_type: 'refresh_token',
+            client_id: client_id,
+            client_secret: client_secret,
+            refresh_token: token.refresh_token
+          };
+          oauth.refreshToken(querystring.stringify(body), {}, function(err, reply) {
+            should.not.exist(err);
+            should.exist(reply.attributes);
+            reply.attributes.foo.should.equal(options.attributes.foo);
+            done();
+          });
+        });
+      });
     });
 
     describe('beforeCreateToken()', function() {


### PR DESCRIPTION
When creating a refresh token the attributes from the old token should
be set on the new token
