### PR TITLE
module apigee.js no longer exists. apigee-example.js does

### DIFF
--- a/samples/training/config/volos.js
+++ b/samples/training/config/volos.js
@@ -23,7 +23,7 @@ var VolosQuotaApigee = require('volos-quota-apigee');
 
 // Provider Configuration
 
-var apigeeConfig = require('./apigee');
+var apigeeConfig = require('./apigee-example');
 var redisConfig = require('./redis');
 
 


### PR DESCRIPTION
npm run cache fails because apigee.js no longer exists. apigee-example.js fixes this issue.