### PR TITLE
Fix fallback cache creation

### DIFF
--- a/cache/apigee/lib/cache.js
+++ b/cache/apigee/lib/cache.js
@@ -74,7 +74,8 @@ function Cache(name, options) {
     cache = apigee.getCache(name, options);
     _.extend(cache, monkeyPatch);
   } else if (options.fallback) {
-    cache = options.fallback.create(name, options);
+    var fallbackModule = require(options.fallback.provider);
+    cache = fallbackModule.create.apply(this, [options.fallback]);
   }
   if (!cache) { throw new Error('Apigee cache not available. Specify options.fallback to avoid error.'); }
 


### PR DESCRIPTION
This fixes a problem I had when I configured a cache using the volos-cache-apigee and tried to run using a RemoteProxy to apigee.  When I first configured the cache, I did not have a 'fallback' configured and when running locally I got an error that said I should create a fallback.  When I did configure a callback, it was not able to create it.  In this case I got an error saying that options.fallback did not have a create method.

After debugging through the code, I was able to follow a pattern I saw elsewhere in the code to dynamically require the provider and use it to create the cache.

After adding this fix, I was able to run both with my RemoteProxy and when running in the Apigee cloud.

Not sure if this is the best fix, but it seems to work.

Hope this helps.

Below is the cache configuration that I used in my swagger file:

```javascript
x-a127-services: 
  cache:
    provider: *cacheProvider
    options:
      name: catalog-cache
      ttl: 60000
      uri: *apigeeProxyUri
      key: *apigeeProxyKey
      fallback:
        name: catalog-cache-memory
        provider: volos-cache-memory
        options:
          ttl: 60000
          maxEntries: 10000
```