### PR TITLE
Fix spike smoothing

### DIFF
--- a/spikearrest/common/lib/memory_buffer.js
+++ b/spikearrest/common/lib/memory_buffer.js
@@ -98,7 +98,11 @@ MemoryBuffer.prototype.internalApply = function(bucket, item) {
     bucket.applying = undefined;
     bucket.nextWindow = now + result.expiryTime;
     self.scheduleBuffer(bucket, now);
-    item.cb(err, result);
+    if (result.isAllowed) {
+      item.cb(err, result);
+    } else {
+      self.buffer(bucket, item.options, now, item.cb);
+    }
   });
 };
 

--- a/spikearrest/test/spikearresttest.js
+++ b/spikearrest/test/spikearresttest.js
@@ -25,6 +25,7 @@
 
 var random = Math.random();
 var _ = require('underscore');
+var async = require('async');
 var assert = require('assert');
 var should = require('should');
 
@@ -184,34 +185,17 @@ exports.testSpikeArrest = function(config, Spi) {
       });
 
       it('should smooth a spike', function(done) {
-        ps.apply({ key: 'y' }, function(err, reply) {
-          should.not.exist(err);
-          reply.allowed.should.equal(6000);
-          reply.used.should.equal(1);
-          reply.isAllowed.should.be.true;
-          reply.expiryTime.should.be.approximately(10, 2);
-
+        var runRequest = function(cb) {
+          console.log(cb);
           ps.apply({ key: 'y' }, function(err, reply) {
             should.not.exist(err);
             reply.allowed.should.equal(6000);
-            reply.used.should.equal(1);
             reply.isAllowed.should.be.true;
             reply.expiryTime.should.be.approximately(10, 2);
-
-            setTimeout(function() {
-
-              ps.apply({ key: 'y' }, function(err, reply) {
-                should.not.exist(err);
-                reply.allowed.should.equal(6000);
-                reply.used.should.equal(1);
-                reply.isAllowed.should.be.true;
-                reply.expiryTime.should.be.approximately(10, 2);
-
-                done();
-              });
-            }, 10);
+            cb(null, true);
           });
-        });
+        }
+        async.parallel([runRequest, runRequest, runRequest], done);
       });
 
       it('should fail when buffer exceeded', function(done) {


### PR DESCRIPTION
Spike smoothing was not working because the buffer would catch any extra
requests and then release them all at once without the protection of the
buffer.  This essentially created its own even more severe spike, and
only one of the released requests would be served.  By checking the
results of the released requests and rebuffering the failed ones, the
requests may take a little longer to resolve, but they only begin to
fail when the buffer is full.

In order to test spike smoothing the tests were updated to run the
requests asynchronously.