### PR TITLE
Fix insecure dependencies for volos-quota

### DIFF
--- a/quota/common/package.json
+++ b/quota/common/package.json
@@ -10,7 +10,7 @@
     "memory"
   ],
   "dependencies": {
-    "debug": "1.0.x",
+    "debug": "2.2.x",
     "underscore": "1.6.x"
   },
   "devDependencies": {},

--- a/quota/redis/package.json
+++ b/quota/redis/package.json
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "volos-quota-common": "0.11.x",
-    "debug": "1.0.x",
+    "debug": "2.2.x",
     "underscore": "1.6.x",
     "redis": "0.10.x"
   },


### PR DESCRIPTION
The required version of `debug` depends on a [`ms` version that is vulnerable](https://nodesecurity.io/advisories/46). This bumps `debug` to a version where the issue is fixed.