### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/management/redis/lib/redismgmt.js
+++ b/management/redis/lib/redismgmt.js
@@ -72,7 +72,7 @@ var CRYPTO_BYTES = 256 / 8;
 
 var debug = require('debug')('apigee');
 var crypto = require('crypto');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var redis = require("redis");
 var _ = require('underscore');
 var Common = require('volos-management-common');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "js-yaml": "^3.5.3",
     "longjohn": "0.2.x",
     "lru-cache-plus": "2.5.x",
-    "node-uuid": "1.4.x",
     "on-finished": "~2.2.1",
     "proxy": "^0.2.4",
     "redis": "0.10.x",
@@ -29,6 +28,7 @@
     "swagger-tools": "^0.8.0",
     "twit": "1.1.x",
     "underscore": "1.6.x",
+    "uuid": "^3.0.0",
     "yamljs": "0.1.x"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.