### PR TITLE
Fix quota buckets

### DIFF
--- a/quota/common/lib/memory_buffer.js
+++ b/quota/common/lib/memory_buffer.js
@@ -121,7 +121,7 @@ Bucket.prototype.reset = function(time) {
 };
 
 Bucket.prototype.calculateExpiration = function() {
-  var time = this.resetAt + this.owner.clockOffset;
+  var time = this.resetAt + (this.owner.clockOffset || 0);
 
   var startTime = this.owner.options.startTime;
   var timeInterval = this.owner.options.timeInterval;


### PR DESCRIPTION
I'm not sure if nobody is using quota in microgateway but we couldn't get quotas to work against apigee without this fix...
Initially clockOffset is undefined which leads to ``int + undefined == NaN`` which leads to all kinds of side effects...
There's still some weird things going in like occasional requests going through although quota is depleted, but in general we now have _some_ quota.

The behavior we were seeing is the following loop: 
```
  quota flushing bucket:  pschleier +2s
  apigee Remote quota request: {"identifier":"pschleier","weight":1,"interval":1,"allow":5,"timeUnit":"minute","quotaType":"flexi"} +0ms
  apigee Quota result: {"allowed":5,"used":1,"exceeded":0,"available":4,"expiryTime":568,"timestamp":1505914746621} +26ms
  quota new time bucket +0ms
  quota flushing bucket:  pschleier +5s
  apigee Remote quota request: {"identifier":"pschleier","weight":1,"interval":1,"allow":5,"timeUnit":"minute","quotaType":"flexi"} +0ms
  apigee Quota result: {"allowed":5,"used":2,"exceeded":0,"available":3,"expiryTime":55570,"timestamp":1505914751619} +22ms
  quota new time bucket +0ms
```
On its own (flushBuffer interval) it would just keep adding 1 to count and reporting that as weight. Since it returns with "new time bucket", it never subtracts the weight from self.count and just keeps counting up.