### PR TITLE
Fixes bug in quota time calculation

### DIFF
--- a/quota/common/lib/quota.js
+++ b/quota/common/lib/quota.js
@@ -74,6 +74,7 @@ function Quota(Spi, o) {
   } else if ('month' === options.timeUnit) {
     options.timeInterval = MONTH;
   }
+  options.timeInterval *= options.interval;
 
   if (options.bufferSize && !options.bufferTimeout) { options.bufferTimeout = MINUTE; }
 


### PR DESCRIPTION
The "interval" parameter was always accepted and checked, but not actually applied anywhere.

No tests have been modified because we have never got the Volos test suites working.