### PR TITLE
138622990 Make response status code configurable on quota violation

### DIFF
--- a/quota/common/lib/quota-connect.js
+++ b/quota/common/lib/quota-connect.js
@@ -117,9 +117,9 @@ function applyQuota(self, options, resp, next, req) {
       resp.setHeader('X-RateLimit-Reset', (reply.expiryTime / 1000) >> 0);
       if (!reply.isAllowed) {
         debug('Quota exceeded:', options.identifier);
-        resp.statusCode = 403;
+        resp.statusCode = self.quota.options.isHTTPStatusTooManyRequestEnabled ? 429 : 403;
         err = new Error('exceeded quota');
-        err.status = 403;
+        err.status = resp.statusCode;
       }
       next(err);
     }


### PR DESCRIPTION
  - Introduced the new config "isHTTPStatusTooManyRequestEnabled" to make
    the HTTP status code configurable in case of exceeded quota error
  - If the flag is true, the quota policy will return HTTP status code 429
    and by default it will return HTTP status code 403 if config is not
    mentioned or set to false