### PR TITLE
Fixed the markdown to show the status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Status](https://coveralls.io/repos/github/apigee-127/volos/badge.svg?branch=master)](https://coveralls.io/github/apigee-127/volos?branch=master)
+[![Status](https://coveralls.io/repos/github/apigee-127/volos/badge.svg?branch=master)](https://coveralls.io/github/apigee-127/volos?branch=master)
 
 Apigee Volos
 ============


### PR DESCRIPTION
This PR aims to fix the markdown for showing the status badge in the `README.md`

[![Status](https://coveralls.io/repos/github/apigee-127/volos/badge.svg?branch=master)](https://coveralls.io/github/apigee-127/volos?branch=master)

