### PR TITLE
491053997 upgrade underscore to 1.13.8

### DIFF
--- a/analytics/apigee/.npmignore
+++ b/analytics/apigee/.npmignore
@@ -1,0 +1,5 @@
+package-lock.json
+npm-shrinkwrap.json
+node_modules/
+.idea/
+*.log

--- a/analytics/apigee/package.json
+++ b/analytics/apigee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volos-analytics-apigee",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "lib/apigeeanalytics.js",
   "license": "MIT",
   "description": "Apigee provider for Analytics in the Volos system.",
@@ -13,9 +13,9 @@
     "debug": "^2.2.0",
     "on-finished": "~2.2.1",
     "postman-request": "^2.88.1-postman.43",
-    "volos-analytics-common": "^0.2.5"
+    "volos-analytics-common": "^0.2.6",
+    "volos-util-apigee": "^0.1.7"
   },
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/apigee/volos.git"

--- a/analytics/common/.npmignore
+++ b/analytics/common/.npmignore
@@ -1,0 +1,5 @@
+package-lock.json
+npm-shrinkwrap.json
+node_modules/
+.idea/
+*.log

--- a/analytics/common/package.json
+++ b/analytics/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volos-analytics-common",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "lib/analytics.js",
   "license": "MIT",
   "description": "Common module for Analytics in the Volos system.",

--- a/cache/common/.npmignore
+++ b/cache/common/.npmignore
@@ -1,0 +1,5 @@
+package-lock.json
+npm-shrinkwrap.json
+node_modules/
+.idea/
+*.log

--- a/cache/common/package.json
+++ b/cache/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volos-cache-common",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "main": "lib/cache.js",
   "license": "MIT",
   "description": "Basic caching library for the Volos system.",
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "debug": "^2.2.0",
-    "underscore": "^1.13.6"
+    "underscore": "1.13.8"
   },
   "devDependencies": {},
   "repository": {

--- a/quota/apigee/.npmignore
+++ b/quota/apigee/.npmignore
@@ -1,0 +1,5 @@
+package-lock.json
+npm-shrinkwrap.json
+node_modules/
+.idea/
+*.log

--- a/quota/apigee/package.json
+++ b/quota/apigee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volos-quota-apigee",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "main": "lib/apigeequota.js",
   "license": "MIT",
   "description": "Apigee provider for Quota enforcement in the Volos system.",
@@ -14,7 +14,8 @@
     "debug": "^2.2.0",
     "postman-request": "^2.88.1-postman.43",
     "semver": "7.x.x",
-    "volos-quota-common": "^0.11.12"
+    "volos-quota-common": "^0.11.14",
+    "volos-util-apigee": "^0.1.7"
   },
   "devDependencies": {
     "proxy": "^1.0.2"

--- a/quota/common/.npmignore
+++ b/quota/common/.npmignore
@@ -1,0 +1,5 @@
+package-lock.json
+npm-shrinkwrap.json
+node_modules/
+.idea/
+*.log

--- a/quota/common/package.json
+++ b/quota/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volos-quota-common",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "main": "lib/quota.js",
   "license": "MIT",
   "description": "Common library for Quota enforcement in the Volos system.",
@@ -11,7 +11,7 @@
   ],
   "dependencies": {
     "debug": "^2.2.0",
-    "underscore": "^1.13.6"
+    "underscore": "1.13.8"
   },
   "devDependencies": {},
   "repository": {

--- a/quota/redis/.npmignore
+++ b/quota/redis/.npmignore
@@ -1,0 +1,5 @@
+package-lock.json
+npm-shrinkwrap.json
+node_modules/
+.idea/
+*.log

--- a/quota/redis/package.json
+++ b/quota/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volos-quota-redis",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "main": "lib/redisquota.js",
   "license": "MIT",
   "description": "Redis provider for Quota enforcement in the Volos system.",
@@ -10,12 +10,11 @@
     "redis"
   ],
   "dependencies": {
-    "volos-quota-common": "^0.11.13",
     "debug": "^2.2.0",
-    "underscore": "^1.13.6",
-    "redis": "0.10.x"
+    "redis": "0.10.x",
+    "underscore": "1.13.8",
+    "volos-quota-common": "^0.11.14"
   },
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/apigee/volos.git"

--- a/spikearrest/common/.npmignore
+++ b/spikearrest/common/.npmignore
@@ -1,0 +1,5 @@
+package-lock.json
+npm-shrinkwrap.json
+node_modules/
+.idea/
+*.log

--- a/spikearrest/common/package.json
+++ b/spikearrest/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volos-spikearrest-common",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "main": "lib/spikearrest.js",
   "license": "MIT",
   "description": "Common library for Spike Arrest enforcement in the Volos system.",
@@ -11,9 +11,8 @@
   ],
   "dependencies": {
     "debug": "^2.2.0",
-    "underscore": "^1.13.6"
+    "underscore": "1.13.8"
   },
-  "devDependencies": {},
   "repository": {
     "type": "git",
     "url": "https://github.com/apigee/volos.git"

--- a/util/apigee/.npmignore
+++ b/util/apigee/.npmignore
@@ -1,0 +1,5 @@
+package-lock.json
+npm-shrinkwrap.json
+node_modules/
+.idea/
+*.log

--- a/util/apigee/package.json
+++ b/util/apigee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volos-util-apigee",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Apigee Edge Utils",
   "main": "lib/main.js",
   "bin": {
@@ -27,7 +27,9 @@
     "postman-request": "^2.88.1-postman.43",
     "read": "^1.0.7",
     "tar-fs": "^2.1.2",
-    "tmp": "^0.2.5"
+    "tmp": "^0.2.5",
+    "volos-cache-common": "^0.10.10",
+    "volos-quota-common": "^0.11.14"
   },
   "devDependencies": {
     "connect": "^3.4.0",


### PR DESCRIPTION
 - Fixes recursion vulnerability (CVE-2021-23358).
 - Adds .npmignore to exclude lockfiles from publication.
 - Resolves circular dependency between util and spikearrest.
 - Bumps patch versions for 8 sub-packages.